### PR TITLE
demonstration of matlabs inability to resolve multiple inheritance

### DIFF
--- a/Examples/Makefile.in
+++ b/Examples/Makefile.in
@@ -484,7 +484,7 @@ MATLAB_SCRIPT = $(SRCDIR)$(RUNME)
 
 matlab: $(SRCDIR_SRCS)
 	$(SWIG) -matlab $(SWIGOPT) -o $(ISRCS) $(INTERFACEPATH)
-	$(MATLAB_MEX) -g $(CFLAGS) $(ISRCS) $(SRCDIR_SRCS) $(SRCDIR_CSRCS) $(INCLUDES) $(LIBS) -o $(TARGET)_wrap
+	$(MATLAB_MEX) -g $(CFLAGS) $(ISRCS) $(SRCDIR_SRCS) $(SRCDIR_CSRCS) $(INCLUDES) $(LIBS) -output $(TARGET)_wrap
 
 # -----------------------------------------------------------------
 # Build a C++ dynamically loadable module
@@ -492,14 +492,14 @@ matlab: $(SRCDIR_SRCS)
 
 matlab_cpp: $(SRCDIR_SRCS)
 	$(SWIG) -c++ -matlab $(SWIGOPT) -o $(ICXXSRCS) $(INTERFACEPATH)
-	$(MATLAB_MEX) -g $(CPPFLAGS) $(CXXFLAGS) $(ICXXSRCS) $(SRCDIR_SRCS) $(SRCDIR_CSRCS) $(INCLUDES) $(LIBS) -o $(TARGET)_wrap
+	$(MATLAB_MEX) -g $(CPPFLAGS) $(CXXFLAGS) $(ICXXSRCS) $(SRCDIR_SRCS) $(SRCDIR_CSRCS) $(INCLUDES) $(LIBS) -output $(TARGET)_wrap
 
 # -----------------------------------------------------------------
 # Running an Matlab example
 # -----------------------------------------------------------------
 
 matlab_run:
-	 $(RUNTOOL) $(MATLAB) -r "try $(MATLAB_SCRIPT); catch err, fprintf(2,['ERROR: ' err.message '\n']),exit(1), end, exit(0)" $(RUNPIPE)
+	 $(RUNTOOL) $(MATLAB) -r "try; $(MATLAB_SCRIPT); catch err, fprintf(2,['ERROR: ' err.message '\n']),exit(1), end, exit(0)" $(RUNPIPE)
 
 # -----------------------------------------------------------------
 # Version display

--- a/Examples/Makefile.in
+++ b/Examples/Makefile.in
@@ -492,7 +492,7 @@ matlab: $(SRCDIR_SRCS)
 
 matlab_cpp: $(SRCDIR_SRCS)
 	$(SWIG) -c++ -matlab $(SWIGOPT) -o $(ICXXSRCS) $(INTERFACEPATH)
-	$(MATLAB_MEX) -g $(CPPFLAGS) $(CXXFLAGS) $(ICXXSRCS) $(SRCDIR_SRCS) $(SRCDIR_CSRCS) $(INCLUDES) $(LIBS) -o $(TARGET)_wrap
+	$(MATLAB_MEX) -g $(CPPFLAGS) $(CXXFLAGS) $(ICXXSRCS) $(SRCDIR_SRCS) $(SRCDIR_CXXSRCS) $(INCLUDES) $(LIBS) -o $(TARGET)_wrap
 
 # -----------------------------------------------------------------
 # Running an Matlab example

--- a/Examples/matlab/class/example.cxx
+++ b/Examples/matlab/class/example.cxx
@@ -26,3 +26,13 @@ double Square::area(void) {
 double Square::perimeter(void) {
   return 4*width;
 }
+
+double CircleInscribedInSquare::area(void) {
+  return Square::area() - Circle::area();
+}
+
+#ifdef FIXME_SWIGMATLAB
+double CircleInscribedInSquare::perimeter(void) {
+  return Square::perimeter() + Circle::area();
+}
+#endif

--- a/Examples/matlab/class/example.h
+++ b/Examples/matlab/class/example.h
@@ -43,3 +43,17 @@ public:
   virtual double area();
   virtual double perimeter();
 };
+
+// Test multiple inheritance
+class CircleInscribedInSquare : public Circle, public Square {
+private:
+public:
+  CircleInscribedInSquare(double w) : Circle(w/2.0), Square(w) { }
+
+  virtual double area();
+//#define FIXME_SWIGMATLAB // uncomment this to demonstrate matlab choke
+#ifdef FIXME_SWIGMATLAB
+  virtual double perimeter();
+#endif
+  // let perimeter resolve itself
+};

--- a/Examples/matlab/class/runme.m
+++ b/Examples/matlab/class/runme.m
@@ -8,6 +8,7 @@
 disp('Creating some objects:')
 c = swigexample.Circle(10);
 s = swigexample.Square(10);
+u = swigexample.CircleInscribedInSquare(10);
 
 % ----- Access a static member -----
 
@@ -23,19 +24,26 @@ c.y = 30;
 s.x = -10;
 s.y = 5;
 
+u.x = 1;
+u.y = 1;
+
 disp(sprintf('Here is their current position:'))
 disp(sprintf('    Circle = (%f, %f)',c.x,c.y))
 disp(sprintf('    Square = (%f, %f)',s.x,s.y))
+disp(sprintf(' CinSquare = (%f, %f)',u.x,u.y))
 
 % ----- Call some methods -----
 
 disp('Here are some properties of the shapes:')
-for i=0:1
-  if i
+for i=0:2
+  if i==0
     o = c;
-  else
+  elseif i==1
     o = s;
+  elseif i==2
+    o = u;
   end
+  disp(sprintf('  type      = %s', o.swigType()))
   disp(sprintf('  area      = %f', o.area()))
   disp(sprintf('  perimeter = %f', o.perimeter()))
 end
@@ -48,6 +56,7 @@ disp('Guess I will clean up now')
 % Note: this invokes the virtual destructor
 clear c
 clear s
+clear u
 
 disp(sprintf('%i shapes remain', swigexample.Shape.nshapes));
 disp('Goodbye')

--- a/Examples/matlab/constants/Makefile
+++ b/Examples/matlab/constants/Makefile
@@ -1,0 +1,21 @@
+TOP        = ../..
+SWIG       = $(TOP)/../preinst-swig
+CXXSRCS    =
+TARGET     = example
+INTERFACE  = example.i
+LIBS       = -lm
+SWIGOPT    =
+
+check: build
+	$(MAKE) -f $(TOP)/Makefile SRCDIR='$(SRCDIR)' matlab_run
+
+build:
+	$(MAKE) -f $(TOP)/Makefile SRCDIR='$(SRCDIR)' CXXSRCS='$(CXXSRCS)' SWIG='$(SWIG)' \
+	SWIGOPT='$(SWIGOPT)' TARGET='$(TARGET)' INTERFACE='$(INTERFACE)' matlab_cpp
+
+static:
+	$(MAKE) -f $(TOP)/Makefile SRCDIR='$(SRCDIR)' CXXSRCS='$(CXXSRCS)' SWIG='$(SWIG)' \
+	SWIGOPT='$(SWIGOPT)' TARGET='mymatlab' INTERFACE='$(INTERFACE)' matlab_cpp_static
+
+clean:
+	$(MAKE) -f $(TOP)/Makefile SRCDIR='$(SRCDIR)' TARGET='$(TARGET)' matlab_clean

--- a/Examples/matlab/constants/example.i
+++ b/Examples/matlab/constants/example.i
@@ -1,6 +1,12 @@
 /* File : example.i */
 %module swigexample
 
+%{
+#include <complex>
+%}
+
+%include std_complex.i
+
 /* A few preprocessor macros */
 
 #define    ICONST      42
@@ -23,3 +29,4 @@
 
 %constant int iconst = 37;
 %constant double fconst = 3.14;
+%constant std::complex<double> cxconst(3.14,-3);

--- a/Examples/matlab/constants/runme.m
+++ b/Examples/matlab/constants/runme.m
@@ -7,8 +7,9 @@ disp(sprintf('CCONST2 = %s (this should be on a new line)', swigexample.CCONST2)
 disp(sprintf('SCONST  = %s (should be ''Hello World'')', swigexample.SCONST))
 disp(sprintf('SCONST2 = %s (should be ''"Hello World"'')', swigexample.SCONST2))
 disp(sprintf('EXPR    = %f (should be 48.5484)', swigexample.EXPR))
-%disp(sprintf('iconst  = %i (should be 37)', swigexample.iconst)) % Not working: shadowed by ICONST
-%disp(sprintf('fconst  = %f (should be 3.14)', swigexample.fconst)) % Not working: shadowed by FCONST
+disp(sprintf('iconst  = %i (should be 37)', swigexample.iconst))
+disp(sprintf('fconst  = %f (should be 3.14)', swigexample.fconst))
+% disp(sprintf('cxconst = %s (should be 3.12,-3)', num2str(swigexample.cxconst)))
 
 try
   disp(sprintf('EXTERN = %s (Arg! This shouldn''t printf(anything)', swigexample.EXTERN))

--- a/Examples/matlab/enum/Makefile
+++ b/Examples/matlab/enum/Makefile
@@ -1,0 +1,21 @@
+TOP        = ../..
+SWIG       = $(TOP)/../preinst-swig
+CXXSRCS    = example.cxx
+TARGET     = example
+INTERFACE  = example.i
+LIBS       = -lm
+SWIGOPT    =
+
+check: build
+	$(MAKE) -f $(TOP)/Makefile SRCDIR='$(SRCDIR)' matlab_run
+
+build:
+	$(MAKE) -f $(TOP)/Makefile SRCDIR='$(SRCDIR)' CXXSRCS='$(CXXSRCS)' SWIG='$(SWIG)' \
+	SWIGOPT='$(SWIGOPT)' TARGET='$(TARGET)' INTERFACE='$(INTERFACE)' matlab_cpp
+
+static:
+	$(MAKE) -f $(TOP)/Makefile SRCDIR='$(SRCDIR)' CXXSRCS='$(CXXSRCS)' SWIG='$(SWIG)' \
+	SWIGOPT='$(SWIGOPT)' TARGET='mymatlab' INTERFACE='$(INTERFACE)' matlab_cpp_static
+
+clean:
+	$(MAKE) -f $(TOP)/Makefile SRCDIR='$(SRCDIR)' TARGET='$(TARGET)' matlab_clean

--- a/Examples/test-suite/matlab/Makefile.in
+++ b/Examples/test-suite/matlab/Makefile.in
@@ -457,7 +457,7 @@ include $(srcdir)/../common.mk
 run_testcase = \
 	if [ -f $(SCRIPTDIR)/$(SCRIPTPREFIX)$*$(SCRIPTSUFFIX).m ]; then \
 	 env LD_LIBRARY_PATH=.:$$LD_LIBRARY_PATH MATLABPATH=$(srcdir):$(SCRIPTDIR):$$MATLAB_PATH \
-	 $(RUNTOOL) $(MATLAB) -r "try $(SCRIPTPREFIX)$*$(SCRIPTSUFFIX); catch err, fprintf(2,['ERROR: ' err.message '\n']),exit(1), end, exit(0)"; \
+	 $(RUNTOOL) $(MATLAB) -r "try; $(SCRIPTPREFIX)$*$(SCRIPTSUFFIX); catch err, fprintf(2,['ERROR: ' err.message '\n']),exit(1), end, exit(0)"; \
 	fi
 
 # Clean: remove the generated .m file

--- a/Lib/matlab/matlabopers.swg
+++ b/Lib/matlab/matlabopers.swg
@@ -4,36 +4,35 @@
 
 #ifdef __cplusplus
 
-
 // operators supported in C++, and the methods that route to them
 
-%rename(plus)       *::operator+;
-%rename(uplus)       *::operator+();
-%rename(uplus)       *::operator+() const;
-%rename(minus)       *::operator-;
-%rename(uminus)    *::operator-();
-%rename(uminus)    *::operator-() const;
-%rename(mult)       *::operator*;
+%rename(plus)           *::operator+;
+%rename(uplus)          *::operator+();
+%rename(uplus)          *::operator+() const;
+%rename(minus)          *::operator-;
+%rename(uminus)         *::operator-();
+%rename(uminus)         *::operator-() const;
+%rename(mult)           *::operator*;
 %rename(mrdivide)       *::operator/;
-%rename(mod)       *::operator%;
-// %rename(lshift)    *::operator<<;
-// %rename(rshift)    *::operator>>;
-%rename(TODOand)    *::operator&&; // TODO cannot rename "and"
-%rename(TODOor)     *::operator||;
-%rename(xor)       *::operator^;
-//%rename(invert)    *::operator~;
-%rename(lt)        *::operator<;
-%rename(le)        *::operator<=;
-%rename(gt)        *::operator>;
-%rename(ge)        *::operator>=;
+%rename(mod)            *::operator%;
+// %rename(lshift)      *::operator<<;
+// %rename(rshift)      *::operator>>;
+%rename(TODOand)        *::operator&&; // TODO cannot rename "and"
+%rename(TODOor)         *::operator||;
+%rename(xor)            *::operator^;
+//%rename(invert)       *::operator~;
+%rename(lt)             *::operator<;
+%rename(le)             *::operator<=;
+%rename(gt)             *::operator>;
+%rename(ge)             *::operator>=;
 %rename(isequal)        *::operator==;
-%rename(ne)        *::operator!=;
-%rename(TODOnot)       *::operator!;
+%rename(ne)             *::operator!=;
+%rename(TODOnot)        *::operator!;
 // non-standard matlab
-%rename(TODOincr)      *::operator++;
-%rename(TODOdecr)      *::operator--;
-%rename(TODOparen)     *::operator();
-%rename(TODObrace)     *::operator[];
+%rename(TODOincr)       *::operator++;
+%rename(TODOdecr)       *::operator--;
+%rename(TODOparen)      *::operator();
+%rename(TODObrace)      *::operator[];
 
 // Ignored inplace operators
 %ignoreoperator(PLUSEQ)     operator+=;
@@ -50,5 +49,8 @@
 // Ignored operators
 %ignoreoperator(EQ)         operator=;
 %ignoreoperator(ARROWSTAR)  operator->*;
+%ignoreoperator(ARROW)      operator->;
+%ignoreoperator(PARENS)     operator*();
+%ignoreoperator(PARENSC)    operator*() const;
 
 #endif /* cplusplus */

--- a/Source/Modules/matlab.cxx
+++ b/Source/Modules/matlab.cxx
@@ -83,7 +83,7 @@ protected:
   void toConstant(String *constname, String *constdef);
   void finalizeConstant();
   void createSwigRef();
-  void autodoc_to_m(Node *n);
+  void autodoc_to_m(File* f, Node *n);
   void process_autodoc(Node *n);
   void make_autodocParmList(Node *n, String *decl_str, String *args_str);
   void addMissingParameterNames(ParmList *plist, int arg_offset);
@@ -857,7 +857,7 @@ int MATLAB::globalfunctionHandler(Node *n){
 
   // Add function to matlab proxy
   Printf(f_wrap_m,"function varargout = %s(varargin)\n",symname);
-  autodoc_to_m(n);
+  autodoc_to_m(f_wrap_m, n);
   if (min_num_returns==0) {
     Printf(f_wrap_m,"  [varargout{1:nargout}] = %s(%d,'%s',varargin{:});\n",mex_fcn,gw_ind,wname);
   } else {
@@ -1233,7 +1233,7 @@ int MATLAB::memberfunctionHandler(Node *n) {
 
   // Add function to .m wrapper
   Printf(f_wrap_m,"    function varargout = %s(self,varargin)\n",symname);
-  autodoc_to_m(n);
+  autodoc_to_m(f_wrap_m, n);
   if (min_num_returns==0) {
     Printf(f_wrap_m,"      [varargout{1:nargout}] = %s(%d,'%s',self,varargin{:});\n",mex_fcn,gw_ind,fullname);
   } else {
@@ -1463,7 +1463,7 @@ int MATLAB::staticmemberfunctionHandler(Node *n) {
 
   // Add function to .m wrapper
   Printf(static_methods,"    function varargout = %s(varargin)\n",symname);
-  autodoc_to_m(n);
+  autodoc_to_m(static_methods, n);
   if (min_num_returns==0) {
     Printf(static_methods,"      [varargout{1:nargout}] = %s(%d,'%s',varargin{:});\n",mex_fcn,gw_ind,fullname);
   } else {
@@ -1698,24 +1698,24 @@ String* MATLAB::matlab_escape(String *_s) {
   return r;
 }
 
-void MATLAB::autodoc_to_m(Node *n)
+void MATLAB::autodoc_to_m(File* f, Node *n)
 {
   if (!n)
     return;
   process_autodoc(n);
   String *synopsis = Getattr(n, "matlab:synopsis");
   String *decl_info = Getattr(n, "matlab:decl_info");
-  String *cdecl_info = Getattr(n, "matlab:cdecl_info");
+  // String *cdecl_info = Getattr(n, "matlab:cdecl_info");
   String *args_info = Getattr(n, "matlab:args_info");
 
   if (Len(synopsis)>0)
-    Printf(f_wrap_m,"    %%%s\n", matlab_escape(synopsis));
+    Printf(f,"    %%%s\n", matlab_escape(synopsis));
   if (Len(decl_info)>0)
-    Printf(f_wrap_m,"    %%%s\n", matlab_escape(decl_info));
-  if (Len(cdecl_info)>0)
-    Printf(f_wrap_m,"    %%%s\n", matlab_escape(cdecl_info));
+    Printf(f,"    %%%s\n", matlab_escape(decl_info));
+  // if (Len(cdecl_info)>0)
+  //   Printf(f,"    %%%s\n", matlab_escape(cdecl_info));
   if (Len(args_info)>0)
-    Printf(f_wrap_m,"    %%%s\n", matlab_escape(args_info));
+    Printf(f,"    %%%s\n", matlab_escape(args_info));
 }
 
 int MATLAB::getRangeNumReturns(Node *n, int &max_num_returns, int &min_num_returns) {

--- a/configure.ac
+++ b/configure.ac
@@ -1020,7 +1020,7 @@ fi
 MATLAB_MEX=
 if test x"$MATLAB" != x; then
   AC_MSG_CHECKING([for Matlab mex command])
-  AC_PATH_PROG(MATLAB_MEX, [mex], [], [$MATLAB_HOME/bin])
+  AC_PATH_PROG(MATLAB_MEX, [mex], [], [$MATLAB_HOME/bin$PATH_SEPARATOR$PATH])
   if test x"$MATLAB_MEX" = x; then
     AC_MSG_WARN([Cannot find mex command. Disabling matlab])
     MATLAB=
@@ -1030,13 +1030,14 @@ fi
 MATLAB_MEXSUFFIX=
 if test x"$MATLAB" != x; then
   AC_MSG_CHECKING([for Matlab mexext command])
-  AC_PATH_PROG(MATLAB_MEXEXT, [mexext], [], [$MATLAB_HOME/bin])
+  AC_PATH_PROG(MATLAB_MEXEXT, [mexext], [], [$MATLAB_HOME/bin$PATH_SEPARATOR$PATH])
   if test x"$MATLAB_MEXEXT" = x; then
     AC_MSG_WARN([Cannot find mexext command. Disabling matlab])
     MATLAB=
+  else
+    MATLAB_MEXSUFFIX=`"$MATLAB_MEXEXT"`
+    AC_MSG_RESULT([$MATLAB_MEXSUFFIX])
   fi
-  MATLAB_MEXSUFFIX=`"$MATLAB_MEXEXT"`
-  AC_MSG_RESULT([$MATLAB_MEXSUFFIX])
 fi
 
 AC_SUBST(MATLAB)


### PR DESCRIPTION
this demonstrates that when CircleInscribedInSquare does not define perimeter(), matlab doesn't know which inherited perimeter to resolve, and just chokes.  at least would be nice to print out a warning.

to test this case un/comment the line
//#define FIXME_SWIGMATLAB
