### PR TITLE
[MATLAB] Fix operator* overloading

### DIFF
--- a/Lib/matlab/matlabopers.swg
+++ b/Lib/matlab/matlabopers.swg
@@ -12,7 +12,7 @@
 %rename(minus)          *::operator-;
 %rename(uminus)         *::operator-();
 %rename(uminus)         *::operator-() const;
-%rename(mult)           *::operator*;
+%rename(mtimes)           *::operator*;
 %rename(mrdivide)       *::operator/;
 %rename(mod)            *::operator%;
 // %rename(lshift)      *::operator<<;


### PR DESCRIPTION
Currently `operator*` is renamed to the `mult` method, but the `*` operators is overloaded in matlab using the `mtimes` method. 

Ref: http://www.mathworks.com/help/matlab/matlab_oop/implementing-operators-for-your-class.html
