### PR TITLE
[MATLAB] Introduce the possibility to have define setup script

### DIFF
--- a/Lib/matlab/matlab.swg
+++ b/Lib/matlab/matlab.swg
@@ -6,3 +6,6 @@
 %include <matlabopers.swg>
 
 %define %docstring %feature("docstring") %enddef
+
+%define %matlabsetup %insert("matlabsetup") %enddef
+


### PR DESCRIPTION
The setup script can be defined as:

%matlabsetup %{

matlab code

%}

For a project foo, this code will end up in a 'foosetup.m'.

The code is automatically run, just before the generated mex file is
called for the first time.

The code runs only once unless matlab memory of global variables is
cleared.
