### PR TITLE
Fix paren_asgn in SwigRef

### DIFF
--- a/Source/Modules/matlab.cxx
+++ b/Source/Modules/matlab.cxx
@@ -2671,7 +2671,7 @@ void MATLAB::createSwigRef() {
   Printf(f_wrap_m,"          case '.'\n");
   Printf(f_wrap_m,"            builtin('subsref',self,substruct('.',s.subs,'()',{v}));\n");
   Printf(f_wrap_m,"          case '()'\n");
-  Printf(f_wrap_m,"            builtin('subsref',self,substruct('.','setparen','()',{v, s.subs{:}}));\n");
+  Printf(f_wrap_m,"            builtin('subsref',self,substruct('.','paren_asgn','()',{v, s.subs{:}}));\n");
   Printf(f_wrap_m,"          case '{}'\n");
   Printf(f_wrap_m,"            builtin('subsref',self,substruct('.','setbrace','()',{v, s.subs{:}}));\n");
   Printf(f_wrap_m,"        end\n");


### PR DESCRIPTION
use paren_asgn to be consistent with matlabcontainer.swg. Not sure what to do with setbrace. See Issue #39
