### PR TITLE
Bug fixes & module mexname option support

### DIFF
--- a/Lib/matlab/matlabcontainer.swg
+++ b/Lib/matlab/matlabcontainer.swg
@@ -516,7 +516,7 @@ namespace swig
     }
 
     // KT TODO need to get this in matlab conventions
-    void paren_asgn(difference_type i, value_type x) throw (std::out_of_range) {
+    void paren_asgn(value_type x, difference_type i) throw (std::out_of_range) {
       *(swig::getpos(self,i)) = x;
     }
 

--- a/Lib/matlab/matlabrun.swg
+++ b/Lib/matlab/matlabrun.swg
@@ -280,11 +280,11 @@ SWIGRUNTIME swig_module_info *SWIG_Matlab_GetModule(void *SWIGUNUSEDPARM(clientd
     /* First call for this module, fetch pointer from MATLAB */
     mxArray* mem = 0;
     int flag = mexCallMATLAB(1, &mem, 0, 0, "SwigMem");
-    if (flag || !mem) mexErrMsgIdAndTxt("SWIG_Matlab_GetModule", "Cannot call SwigMem");
+    if (flag || !mem) mexErrMsgIdAndTxt("SWIG:GetModule", "Cannot call SwigMem");
     /* On first call, mem is an empty matrix */
     if (mxGetNumberOfElements(mem)!= 0) {
       if (!mxIsStruct(mem)) {
-        mexErrMsgIdAndTxt("SWIG_Matlab_GetModule", "Corrupted memory");
+        mexErrMsgIdAndTxt("SWIG:GetModule", "Corrupted memory");
       }
       mxArray *module = mxGetField(mem, 0,
         "swig_runtime_data_type_pointer" SWIG_RUNTIME_VERSION SWIG_TYPE_TABLE_NAME);
@@ -302,7 +302,7 @@ SWIGRUNTIME void SWIG_Matlab_SetModule(swig_module_info *pointer) {
   mxArray* mem = 0;
   const char *fields[1] = {"swig_runtime_data_type_pointer" SWIG_RUNTIME_VERSION SWIG_TYPE_TABLE_NAME};
   int flag = mexCallMATLAB(1, &mem, 0, 0, "SwigMem");
-  if (flag || !mem) mexErrMsgIdAndTxt("SWIG_Matlab_GetModule", "Cannot call SwigMem");
+  if (flag || !mem) mexErrMsgIdAndTxt("SWIG:SetModule", "Cannot call SwigMem");
   /* Under normal circumstances, swigMem is an empty matrix */
   /* but is not required to be for a valid call to SWIG_Matlab_SetModule() */
   if (mxGetNumberOfElements(mem) == 0) {
@@ -318,7 +318,7 @@ SWIGRUNTIME void SWIG_Matlab_SetModule(swig_module_info *pointer) {
     int fieldNum = 0;
     /* Add to existing mem if not the same */
     if (!mxIsStruct(mem)) {
-      mexErrMsgIdAndTxt("SWIG_Matlab_GetModule", "Corrupted memory");
+      mexErrMsgIdAndTxt("SWIG:SetModule", "Corrupted memory");
     }
     nfields = mxGetNumberOfFields(mem);
     /* Check if same type table */
@@ -329,7 +329,7 @@ SWIGRUNTIME void SWIG_Matlab_SetModule(swig_module_info *pointer) {
       }
     }
     fieldNum = mxAddField(mem, fields[0]);
-    if (fieldNum < 0) mexErrMsgIdAndTxt("SWIG_Matlab_GetModule", "Error adding field to SwigMem");
+    if (fieldNum < 0) mexErrMsgIdAndTxt("SWIG:SetModule", "Error adding field to SwigMem");
     mxArray *module = mxCreateNumericMatrix(1, 1, mxUINT64_CLASS, mxREAL);
     if(!module) mexErrMsgIdAndTxt("SWIG:SetModule","mxCreateNumericMatrix failed");
     *(uint64_T *)mxGetData(module) = (uint64_T)pointer;

--- a/Source/Modules/matlab.cxx
+++ b/Source/Modules/matlab.cxx
@@ -20,6 +20,7 @@ static const char *usage = (char *) "\
 Matlab Options (available with -matlab)\n\
      -opprefix <str> - Prefix <str> for global operator functions [default: 'op_']\n\
      -pkgname <str> - Prefix <str> for package name ' [default: '<module_name>']\n\
+     -mexname <str> - Specify mex function name <str> ' [default: '<module_name>MEX']\n\
 \n";
 
 class MATLAB : public Language {
@@ -275,6 +276,11 @@ int MATLAB::top(Node *n) {
         // Otherwise use module name as default (see below)
         if (!pkg_name && Getattr(options, "package")) {
             pkg_name = Getattr(options, "package");
+        }
+        // Set mex name via module option if not set via command-line
+        // Otherwise use module name as default (see below)
+        if (!mex_name && Getattr(options, "mexname")) {
+            mex_name = Getattr(options, "mexname");
         }
       }
     }
@@ -731,10 +737,19 @@ int MATLAB::importDirective(Node *n) {
     String *modname = Getattr(n, "module");
 
     if (modname) {
-      // Construct name of intermediary layer
-      // TODO: If option mexname set for module, use instead
-      String *import_mexname = Copy(modname);
-      Append(import_mexname, "MEX");
+      // Find the module node for this imported module.  It should be the
+      // first child but search just in case.
+      Node *mod = firstChild(n);
+      while (mod && Strcmp(nodeType(mod), "module") != 0)
+        mod = nextSibling(mod);
+
+      // If option mexname set for module, use instead
+      Node *options = Getattr(mod, "options");
+      String *import_mexname = options ? Getattr(options, "mexname") : 0;
+      if (import_mexname == 0) {
+          import_mexname = Copy(modname);
+          Append(import_mexname, "MEX");
+      }
 
       /* Add to list of modules to be imported */
       Append(l_modules, import_mexname);


### PR DESCRIPTION
I tested the new option in my build system. It seems to have fixed the problem. However, I wasn't able to test the the default, i.e. not specifying mexname at all.  It appears like your previous changes broke directors as 'make  check-matlab-test-suite RUNPIPE=>>/tmp/xxx' now hangs. The hang occurred before I made the changes included in this pull request. 
