### PR TITLE
fix duplicate colon matlab error identifiers

### DIFF
--- a/Lib/matlab/matlabtypemaps.swg
+++ b/Lib/matlab/matlabtypemaps.swg
@@ -19,7 +19,7 @@
 #define SWIG_SetConstant(name, obj)     SWIG_Matlab_SetConstant(module_ns,name,obj) 
 
 // raise
-#define SWIG_Matlab_Raise(OBJ, TYPE, DESC) mexErrMsgIdAndTxt("SWIG::RuntimeError", "C++ side threw an exception of type " TYPE)
+#define SWIG_Matlab_Raise(OBJ, TYPE, DESC) mexErrMsgIdAndTxt("SWIG:RuntimeError", "C++ side threw an exception of type " TYPE)
 #define SWIG_Raise(obj, type, desc)     SWIG_Matlab_Raise(obj, type, desc)
 
 /* directors are supported in Matlab */

--- a/Source/Modules/matlab.cxx
+++ b/Source/Modules/matlab.cxx
@@ -432,10 +432,10 @@ int MATLAB::top(Node *n) {
   Iterator i = First(l_modules);
   if (i.item) {
     Printf(f_init, "mxArray *id = mxCreateDoubleScalar(double(4)), *error;\n");
-    Printf(f_init, "if (!id) mexErrMsgIdAndTxt(\"SWIG::RuntimeError\", \"Setup failed\");\n");
+    Printf(f_init, "if (!id) mexErrMsgIdAndTxt(\"SWIG:RuntimeError\", \"Setup failed\");\n");
     for (; i.item; i = Next(i)) {
       Printf(f_init, "error = mexCallMATLABWithTrap(0, 0, 1, &id, \"%s\");\n", i.item);
-      Printf(f_init, "if (error) mexErrMsgIdAndTxt(\"SWIG::RuntimeError\", \"Cannot initialize %s\");\n", i.item);
+      Printf(f_init, "if (error) mexErrMsgIdAndTxt(\"SWIG:RuntimeError\", \"Cannot initialize %s\");\n", i.item);
       Delete(i.item);
     }
     Printf(f_init, "mxDestroyArray(id);\n");


### PR DESCRIPTION
Matlab error IDs must consist only of words and single colon separators,
but runtime errors that get passed up the chain currently use a double
colon (SWIG::RuntimeError) which causes Matlab to complain:

"The error message identifier is invalid."

The fix is to remove the duplicate colon
