### PR TITLE
Fix maybe-uninitialized pointer

### DIFF
--- a/Lib/matlab/matlabrun.swg
+++ b/Lib/matlab/matlabrun.swg
@@ -182,7 +182,7 @@ SWIGRUNTIME mxArray* SWIG_Matlab_NewPointerObj(void *ptr, swig_type_info *type, 
   int own = (flags & SWIG_POINTER_OWN) ? SWIG_POINTER_OWN : 0;
 
   /* Allocate a pointer object */
-  SwigPtr* swig_ptr;
+  SwigPtr* swig_ptr = 0;
   if (SWIG_Matlab_NewPointer(&swig_ptr, ptr, type, own)) {
     mexErrMsgIdAndTxt("SWIG:NewPointerObj","Cannot allocate pointer");
   }


### PR DESCRIPTION
Explicitly initialize the `SwigPtr` in `SWIG_Matlab_NewPointerObj` to null. This fixes a `-wmaybe-uninitialized` warning, because the pointer may or may not be initialized by `SWIG_Matlab_NewPointer`, and is used later in the function.
