### PR TITLE
Fix use of invalid iterator

### DIFF
--- a/Lib/matlab/matlabcontainer.swg
+++ b/Lib/matlab/matlabcontainer.swg
@@ -163,6 +163,8 @@ namespace swig {
       std::advance(sb,ii);
       std::advance(se,jj);
       self->erase(sb,se);
+      sb = self->begin();
+      std::advance(sb,ii);
       self->insert(sb, v.begin(), v.end());
     }
   }


### PR DESCRIPTION
This problem is reported by running cppcheck on the generated C++,
 and originated in the python module, see https://sourceforge.net/p/swig/bugs/1347/ .
Unfortunately it propagated through copy pasting to several other modules. 
The fix used here is directly extracted from the code used in the Python module, see https://github.com/swig/swig/blob/2740812970382202fe97e52f7c881eaa71c2e7c0/Lib/python/pycontainer.swg#L329 .
