### PR TITLE
The Matlab empty string ('') is not recognized as a valid string.

### DIFF
--- a/Lib/matlab/matlabprimtypes.swg
+++ b/Lib/matlab/matlabprimtypes.swg
@@ -230,7 +230,7 @@ SWIG_AsVal_dec(bool)(mxArray* pm, bool *val)
 SWIGINTERN int
 SWIG_AsCharPtrAndSize(mxArray* pm, char** cptr, size_t* psize, int *alloc)
 {
-  if(!mxIsChar(pm) || mxGetM(pm)!=1) return SWIG_TypeError;
+  if(!mxIsChar(pm) || (mxGetNumberOfElements(pm) != 0 && mxGetM(pm)!=1)) return SWIG_TypeError;
   size_t len=mxGetN(pm);
   static char buf[256];
   int flag = mxGetString(pm,buf,(mwSize)sizeof(buf));


### PR DESCRIPTION
I wrapped some C++ methods which wants a std::string object as input. It works for non-empty string but in case of an empty string, it always fails with the error message "No matching function for overload function". The fix in this PR fixed the issue.