### PR TITLE
[matlab] Fix build in C99 mode

### DIFF
--- a/Lib/matlab/matlabrun.swg
+++ b/Lib/matlab/matlabrun.swg
@@ -171,7 +171,7 @@ SWIG_Matlab_CallInterpEx(int nlhs, mxArray *plhs[], int nrhs,
 
 /* Convert a packed value value */
 SWIGRUNTIME int
-SWIG_Matlab_ConvertPacked(mxArray* /*pm*/, void* /*ptr*/, size_t /*sz*/, swig_type_info* /*ty*/) {
+SWIG_Matlab_ConvertPacked(mxArray* SWIGUNUSEDPARM(pm), void* SWIGUNUSEDPARM(ptr), size_t SWIGUNUSEDPARM(sz), swig_type_info* SWIGUNUSEDPARM(ty)) {
   mexErrMsgIdAndTxt("SWIG:ConvertPacked","Not implemented");
   return SWIG_ERROR;
 }
@@ -221,7 +221,7 @@ SWIGRUNTIME mxArray* SWIG_Matlab_NewPointerObj(void *ptr, swig_type_info *type, 
 /* Create a new packed object */
 
 SWIGRUNTIMEINLINE mxArray*
-SWIG_Matlab_NewPackedObj(void* /*ptr*/, size_t /*sz*/, swig_type_info* /*type*/) {
+SWIG_Matlab_NewPackedObj(void* SWIGUNUSEDPARM(ptr), size_t SWIGUNUSEDPARM(sz), swig_type_info* SWIGUNUSEDPARM(type)) {
   mexErrMsgIdAndTxt("SWIG:NewPackedOb","Not implemented");
   return 0;
 }

--- a/Source/Modules/matlab.cxx
+++ b/Source/Modules/matlab.cxx
@@ -592,7 +592,7 @@ int MATLAB::top(Node *n) {
   Printf(f_begin, "}\n\n");
 
   // Touch module
-  Printf(f_begin, "int swigTouch(int resc, mxArray** /*resv*/, int argc, mxArray** /*argv*/) {\n");
+  Printf(f_begin, "int swigTouch(int resc, mxArray** SWIGUNUSEDPARM(resv), int argc, mxArray** SWIGUNUSEDPARM(argv)) {\n");
 
   // Make sure no inputs or outputs
   Printf(f_begin, "  if (argc!=0 || resc!=0) {\n");
@@ -2316,7 +2316,7 @@ void MATLAB::finalizeGateway() {
 void MATLAB::initConstant() {
   if (CPlusPlus)
     Printf(f_constants, "extern \"C\"\n");
-  Printf(f_constants, "int swigConstant(int /*resc*/, mxArray *resv[], int argc, mxArray *argv[]) {\n");
+  Printf(f_constants, "int swigConstant(int SWIGUNUSEDPARM(resc), mxArray *resv[], int argc, mxArray *argv[]) {\n");
 
   // The first argument is always the ID
   Printf(f_constants, "  if (--argc < 0 || !mxIsDouble(*argv) || mxGetNumberOfElements(*argv)!=1) {\n");


### PR DESCRIPTION
The C99 does not allow function signature with just the argument type.
The generated wrapper failed to compile when using the c99 std/
SIG already has a mechanism to deal with the unused parameters.