### PR TITLE
Dynamically allocate char buffers when converting from Matlab strings

### DIFF
--- a/Examples/test-suite/matlab/li_std_string_extra_runme.m
+++ b/Examples/test-suite/matlab/li_std_string_extra_runme.m
@@ -158,3 +158,10 @@ end
 %if (li_std_string_extra.c_null() ~= None)
 %  error
 %end
+
+% Long strings
+s = repmat('hello',1,100);
+sout = li_std_string_extra.test_reference_inout(s);
+if (s ~= sout)
+  error
+end

--- a/Lib/matlab/matlabprimtypes.swg
+++ b/Lib/matlab/matlabprimtypes.swg
@@ -232,17 +232,17 @@ SWIG_AsCharPtrAndSize(mxArray* pm, char** cptr, size_t* psize, int *alloc)
 {
   if(!mxIsChar(pm) || (mxGetNumberOfElements(pm) != 0 && mxGetM(pm)!=1)) return SWIG_TypeError;
   size_t len=mxGetM(pm) * mxGetN(pm) + 1;
-  char* buf = new char[len];
+  char* buf = (char*)malloc(sizeof(char) * len);
   int flag = mxGetString(pm,buf,len);
   if(flag) {
-    delete[] buf;
+    free(buf);
     return SWIG_TypeError;
   }
 
   if (alloc) {
     *cptr = %new_copy_array(buf, len, char);
     *alloc = SWIG_NEWOBJ;
-    delete[] buf;
+    free(buf);
   } else if (cptr)
     *cptr = buf;
   if (psize)

--- a/Lib/matlab/matlabprimtypes.swg
+++ b/Lib/matlab/matlabprimtypes.swg
@@ -231,18 +231,22 @@ SWIGINTERN int
 SWIG_AsCharPtrAndSize(mxArray* pm, char** cptr, size_t* psize, int *alloc)
 {
   if(!mxIsChar(pm) || (mxGetNumberOfElements(pm) != 0 && mxGetM(pm)!=1)) return SWIG_TypeError;
-  size_t len=mxGetN(pm);
-  static char buf[256];
-  int flag = mxGetString(pm,buf,(mwSize)sizeof(buf));
-  if(flag) return SWIG_TypeError;
+  size_t len=mxGetM(pm) * mxGetN(pm) + 1;
+  char* buf = new char[len];
+  int flag = mxGetString(pm,buf,len);
+  if(flag) {
+    delete[] buf;
+    return SWIG_TypeError;
+  }
 
   if (alloc) {
-    *cptr = %new_copy_array(buf, len + 1, char);
+    *cptr = %new_copy_array(buf, len, char);
     *alloc = SWIG_NEWOBJ;
+    delete[] buf;
   } else if (cptr)
     *cptr = buf;
   if (psize)
-    *psize = len + 1;
+    *psize = len;
   return SWIG_OK;
 }
 }

--- a/Lib/matlab/matlabprimtypes.swg
+++ b/Lib/matlab/matlabprimtypes.swg
@@ -243,8 +243,10 @@ SWIG_AsCharPtrAndSize(mxArray* pm, char** cptr, size_t* psize, int *alloc)
     *cptr = %new_copy_array(buf, len, char);
     *alloc = SWIG_NEWOBJ;
     free(buf);
-  } else if (cptr)
+  } else if (cptr) {
     *cptr = buf;
+  } else
+    free(buf);
   if (psize)
     *psize = len;
   return SWIG_OK;


### PR DESCRIPTION
This PR fixes issue #88 