### PR TITLE
Fix extending class in subpackage.

### DIFF
--- a/Source/Modules/matlab.cxx
+++ b/Source/Modules/matlab.cxx
@@ -2105,8 +2105,12 @@ int MATLAB::classHandler(Node *n) {
       }
 #endif
       String *bname = Getattr(b.item, "sym:name");
-      Node *bpkgNode = Getattr(b.item, "module");
-      String *bpkg = Getattr(bpkgNode, "name");
+      Node *bmodNode = Getattr(b.item, "module");
+      Node *bmodoptions = Getattr(bmodNode, "options");
+      String *bpkg = 0;
+      if (bmodoptions) {
+          bpkg = Getattr(bmodoptions, "package");
+      }
       if (!bname || !bpkg || GetFlag(b.item, "feature:ignore"))
 	continue;
       base_count++;


### PR DESCRIPTION
Use base class package name rather than module name because
 MATLAB requires it to be fully qualified.