### PR TITLE
Added Standard Shared Pointer for Matlab

### DIFF
--- a/Lib/matlab/std_shared_ptr.i
+++ b/Lib/matlab/std_shared_ptr.i
@@ -1,0 +1,2 @@
+#define SWIG_SHARED_PTR_NAMESPACE std
+%include <boost_shared_ptr.i>


### PR DESCRIPTION
I needed to wrap code which uses `std::shared_ptr`. The file added is identical to the python `std_shared_ptr.i` file.